### PR TITLE
Support injecting fetch timeout from environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,11 +29,11 @@ services:
     image: danlynn/ember-cli:3.14.0
     working_dir: /company-update/services/app
     entrypoint: ["ember"]
-    command: ["serve", "--port", "9905", "--proxy", "http://graphql"]
+    command: ["serve", "--port", "5555", "--proxy", "http://graphql"]
     tmpfs:
       - /company-update/services/app/tmp
     ports:
-      - "9905:9905"
+      - "5555:5555"
     depends_on:
       - graphql
 
@@ -44,7 +44,7 @@ services:
     depends_on:
       - mongo
     ports:
-      - "9900:80"
+      - "5550:80"
     environment:
       <<: *env
       # Core
@@ -76,7 +76,7 @@ services:
     volumes:
       - mongo:/data/db
     ports:
-      - "9901:27017"
+      - "5551:27017"
 
 volumes:
   mongo: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,7 @@ services:
       NOTIFICATION_TO: ${NOTIFICATION_TO-developer@endeavorb2b.com}
       SENDGRID_API_KEY: ${SENDGRID_API_KEY}
       SENDGRID_FROM: ${SENDGRID_FROM-no-reply@baseplatform.io}
+      FETCH_TIMEOUT: ${FETCH_TIMEOUT-30000}
       # Tenant-specific
       BASE4_API_URL: ${BASE4_API_URL}
       GRAPHQL_URI: ${GRAPHQL_URI}

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 cd services/app
-./node_modules/.bin/ember serve --proxy=http://localhost:9900
+./node_modules/.bin/ember serve --proxy=http://localhost:5550

--- a/services/graphql/src/env.js
+++ b/services/graphql/src/env.js
@@ -27,6 +27,7 @@ module.exports = cleanEnv(process.env, {
   NOTIFICATION_TO: email({ desc: 'The email address notifications are sent to.' }),
   SENDGRID_API_KEY: nonemptystr({ desc: 'The SendGrid API key for sending email.' }),
   SENDGRID_FROM: nonemptystr({ desc: 'The from name to use when sending email via SendGrid, e.g. Foo <foo@bar.com>', default: 'no-reply@baseplatform.io' }),
+  FETCH_TIMEOUT: num({ desc: 'The limit (in ms) for request processing', default: 10000 }),
   // Tenant-specific settings
   BASE4_API_URL: url({ desc: 'The management uri for the related platform tenant.' }),
   GRAPHQL_URI: url({ desc: 'The URI to access the BaseCMS GraphQL instance' }),

--- a/services/graphql/src/schema/base.js
+++ b/services/graphql/src/schema/base.js
@@ -3,7 +3,12 @@ const { setContext } = require('apollo-link-context');
 const { onError } = require('apollo-link-error');
 const fetch = require('node-fetch');
 const { makeRemoteExecutableSchema, introspectSchema } = require('graphql-tools');
-const { GRAPHQL_URI, TENANT_KEY, BASE4_API_URL } = require('../env');
+const {
+  GRAPHQL_URI,
+  TENANT_KEY,
+  BASE4_API_URL,
+  FETCH_TIMEOUT,
+} = require('../env');
 
 const headers = {
   'x-tenant-key': TENANT_KEY,
@@ -14,7 +19,7 @@ const httpLink = new HttpLink({
   uri: GRAPHQL_URI,
   fetch,
   headers,
-  fetchOptions: { timeout: 10000 },
+  fetchOptions: { timeout: FETCH_TIMEOUT },
 });
 
 const authLink = setContext((_, previousContext) => {


### PR DESCRIPTION
This PR adds support for overriding the default fetch timeout (10s) by setting an environment variable.

Allowing for a higher timeout allows complicated publishing operations (such as `createAssetImageFromUrl` with large uploaded files) to complete. Because the acceptable value for these processes will vary, allow further tuning via env.

Also changes ports on dev to no longer conflict with other base-cms projects